### PR TITLE
Update Pippo version to 0.8.0-SNAPSHOT, separate from demo version

### DIFF
--- a/pippo-demo-ajax/pom.xml
+++ b/pippo-demo-ajax/pom.xml
@@ -24,19 +24,19 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-fastjson</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Webjars -->

--- a/pippo-demo-basic/pom.xml
+++ b/pippo-demo-basic/pom.xml
@@ -24,19 +24,19 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-jackson</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
     </dependencies>

--- a/pippo-demo-controller/pom.xml
+++ b/pippo-demo-controller/pom.xml
@@ -24,31 +24,31 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-controller</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-fastjson</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-metrics</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Webjars -->

--- a/pippo-demo-crud/pom.xml
+++ b/pippo-demo-crud/pom.xml
@@ -24,25 +24,25 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-fastjson</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-metrics</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Webjars -->

--- a/pippo-demo-crudko/pom.xml
+++ b/pippo-demo-crudko/pom.xml
@@ -24,31 +24,31 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-controller</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-fastjson</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-metrics</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Webjars -->

--- a/pippo-demo-crudng/pom.xml
+++ b/pippo-demo-crudng/pom.xml
@@ -24,31 +24,31 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-controller</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-fastjson</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-metrics</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Webjars -->

--- a/pippo-demo-css/pom.xml
+++ b/pippo-demo-css/pom.xml
@@ -22,13 +22,13 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-sasscompiler</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pippo-demo-custom/pom.xml
+++ b/pippo-demo-custom/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
     </dependencies>
 

--- a/pippo-demo-guice/pom.xml
+++ b/pippo-demo-guice/pom.xml
@@ -24,19 +24,19 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-guice</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Webjars -->

--- a/pippo-demo-session/pom.xml
+++ b/pippo-demo-session/pom.xml
@@ -18,13 +18,13 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-session-cookie</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
     </dependencies>
 

--- a/pippo-demo-spring/pom.xml
+++ b/pippo-demo-spring/pom.xml
@@ -24,19 +24,19 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-spring</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Webjars -->

--- a/pippo-demo-template/pom.xml
+++ b/pippo-demo-template/pom.xml
@@ -18,50 +18,50 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-metrics</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Templates -->
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-jade</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-trimou</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-pebble</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-groovy</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-velocity</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Webjars -->

--- a/pippo-demo-upload/pom.xml
+++ b/pippo-demo-upload/pom.xml
@@ -18,13 +18,13 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
     </dependencies>
 

--- a/pippo-demo-validation/pom.xml
+++ b/pippo-demo-validation/pom.xml
@@ -18,13 +18,13 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Validation -->

--- a/pippo-demo-weld/pom.xml
+++ b/pippo-demo-weld/pom.xml
@@ -24,26 +24,26 @@
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-tomcat</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-freemarker</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-weld</artifactId>
-            <version>${project.version}</version>
+            <version>${pippo.version}</version>
         </dependency>
 
         <!-- Webjars -->

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <java.version>1.8</java.version>
         <slf4j.version>1.7.7</slf4j.version>
 
-        <pippo.version>@{project.version}</pippo.version>
+        <pippo.version>0.8.0-SNAPSHOT</pippo.version>
     </properties>
 
     <build>
@@ -178,12 +178,12 @@
                 <dependency>
                     <groupId>ro.pippo</groupId>
                     <artifactId>pippo-jetty</artifactId>
-                    <version>${project.version}</version>
+                    <version>${pippo.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>ro.pippo</groupId>
                     <artifactId>pippo-jaxb</artifactId>
-                    <version>${project.version}</version>
+                    <version>${pippo.version}</version>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
Update to Pippo 0.8.0-SNAPSHOT and specify separate version for the Pippo dependencies.  This allows changing the Pippo version without having to reversion all demo projects.
